### PR TITLE
Implement the Send trait for compatibility with RTIC

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@ pub struct Ws2812<SM: ValidStateMachine, C: CountDown> {
     cd: C,
 }
 
+unsafe impl<SM: ValidStateMachine, C: CountDown> Send for Ws2812<SM, C> {}
+
 impl<P: PIOExt, SM: StateMachineIndex, C> Ws2812<(P, SM), C>
 where
     C: CountDown,


### PR DESCRIPTION
In order to use this crate with RTIC, it must be possible to Send it to a task thread.