### PR TITLE
Take ownership of the pin rather than just its ID.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,30 +7,45 @@ use embedded_time::{
     duration::{Extensions, Microseconds},
     fixed_point::FixedPoint,
 };
-use rp2040_hal::pio::{PIOExt, StateMachineIndex, Tx, UninitStateMachine, ValidStateMachine, PIO};
+use rp2040_hal::{
+    gpio::{Function, FunctionConfig, Pin, PinId, ValidPinMode},
+    pio::{PIOExt, StateMachineIndex, Tx, UninitStateMachine, PIO},
+};
 use smart_leds_trait::SmartLedsWrite;
 
 /// Instance of WS2812 LED chain.
-pub struct Ws2812<SM: ValidStateMachine, C: CountDown> {
-    tx: Tx<SM>,
+pub struct Ws2812<P, SM, C, I>
+where
+    I: PinId,
+    C: CountDown,
+    P: PIOExt + FunctionConfig,
+    Function<P>: ValidPinMode<I>,
+    SM: StateMachineIndex,
+{
+    tx: Tx<(P, SM)>,
     cd: C,
+    _pin: Pin<I, Function<P>>,
 }
 
-impl<P: PIOExt, SM: StateMachineIndex, C> Ws2812<(P, SM), C>
+impl<P, SM, C, I> Ws2812<P, SM, C, I>
 where
+    I: PinId,
     C: CountDown,
+    P: PIOExt + FunctionConfig,
+    Function<P>: ValidPinMode<I>,
+    SM: StateMachineIndex,
 {
     /// Creates a new instance of this driver.
     pub fn new(
-        pin_id: u8,
+        pin: Pin<I, Function<P>>,
         pio: &mut PIO<P>,
-        pio_sm: UninitStateMachine<(P, SM)>,
+        sm: UninitStateMachine<(P, SM)>,
         clock_freq: embedded_time::rate::Hertz,
         cd: C,
-    ) -> Ws2812<(P, SM), C> {
+    ) -> Ws2812<P, SM, C, I> {
         // prepare the PIO program
         let side_set = pio::SideSet::new(false, 1, false);
-        let mut a = pio::Assembler::<32>::new_with_side_set(side_set);
+        let mut a = pio::Assembler::new_with_side_set(side_set);
 
         const T1: u8 = 2; // start bit
         const T2: u8 = 5; // data bit
@@ -41,8 +56,6 @@ where
         let mut wrap_target = a.label();
         let mut wrap_source = a.label();
         let mut do_zero = a.label();
-        // sets pin as Out
-        a.set_with_side_set(pio::SetDestination::PINDIRS, 1, 0);
         a.bind(&mut wrap_target);
         // Do stop bit
         a.out_with_delay_and_side_set(pio::OutDestination::X, 1, T3 - 1, 0);
@@ -51,15 +64,8 @@ where
         // Do data bit = 1
         a.jmp_with_delay_and_side_set(pio::JmpCondition::Always, &mut wrap_target, T2 - 1, 1);
         a.bind(&mut do_zero);
-        // Pseudoinstruction: NOP
         // Do data bit = 0
-        a.mov_with_delay_and_side_set(
-            pio::MovDestination::Y,
-            pio::MovOperation::None,
-            pio::MovSource::Y,
-            T2 - 2, // 1 extra cycle in the loop
-            0,
-        );
+        a.nop_with_delay_and_side_set(T2 - 2, 0);
         a.bind(&mut wrap_source);
         let program = a.assemble_with_wrap(wrap_source, wrap_target);
 
@@ -69,35 +75,42 @@ where
         // Configure the PIO state machine.
         let div = clock_freq.integer() as f32 / (FREQ as f32 * CYCLES_PER_BIT as f32);
 
-        let (pio_sm, _, tx) = rp2040_hal::pio::PIOBuilder::from_program(installed)
+        let (mut sm, _, tx) = rp2040_hal::pio::PIOBuilder::from_program(installed)
             // only use TX FIFO
             .buffers(rp2040_hal::pio::Buffers::OnlyTx)
             // Pin configuration
-            .set_pins(pin_id, 1)
-            .side_set_pin_base(pin_id)
+            .side_set_pin_base(I::DYN.num)
             // OSR config
             .out_shift_direction(rp2040_hal::pio::ShiftDirection::Left)
             .autopull(true)
             .pull_threshold(24)
             .clock_divisor(div)
-            .build(pio_sm);
-        pio_sm.start();
+            .build(sm);
 
-        Self { tx, cd }
+        // Prepare pin's direction.
+        sm.set_pindirs([(I::DYN.num, rp2040_hal::pio::PinDir::Output)]);
+
+        sm.start();
+
+        Self { tx, cd, _pin: pin }
     }
 }
 
-impl<SM: ValidStateMachine, C> SmartLedsWrite for Ws2812<SM, C>
+impl<P, SM, C, I> SmartLedsWrite for Ws2812<P, SM, C, I>
 where
-    C: embedded_hal::timer::CountDown,
+    I: PinId,
+    C: CountDown,
     C::Time: From<Microseconds>,
+    P: PIOExt + FunctionConfig,
+    Function<P>: ValidPinMode<I>,
+    SM: StateMachineIndex,
 {
     type Color = smart_leds_trait::RGB8;
     type Error = ();
-    fn write<T, I>(&mut self, iterator: T) -> Result<(), ()>
+    fn write<T, J>(&mut self, iterator: T) -> Result<(), ()>
     where
-        T: Iterator<Item = I>,
-        I: Into<Self::Color>,
+        T: Iterator<Item = J>,
+        J: Into<Self::Color>,
     {
         self.cd.start(60.microseconds());
         let _ = nb::block!(self.cd.wait());


### PR DESCRIPTION
Allows for much cleaner:
```rust
let mut ws = Ws2812::new(
    pins.neopixel.into_mode(),
    &mut pio,
    sm0,
    clocks.peripheral_clock.freq(),
    timer.count_down(),
);
```