### PR TITLE
Update to rp2040-hal 0.3.0 crates.io release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 embedded-hal = "*"
 embedded-time = "*"
-rp2040-hal = { git = "https://github.com/rp-rs/rp-hal.git", branch = "main" }
+rp2040-hal = "0.3.0"
 pio = "0.1.0"
 smart-leds-trait = "0.2.1"
 nb = "1.0.0"


### PR DESCRIPTION
Update to the released HAL so users don't have to use cargo.toml patches to use ws2812-pio-rs