### PR TITLE
Allow less blocking writes with Ws2812Direct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 /// This driver implements driving a WS2812 RGB LED strip from
 /// a PIO device of the RP2040 chip.
 ///
-/// You should reach to the [Ws2812] if you run the main loop
+/// You should reach to [Ws2812] if you run the main loop
 /// of your controller yourself and you want [Ws2812] to take
 /// a hold of your timer.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@
 ///
 /// You should reach to the [Ws2812] if you run the main loop
 /// of your controller yourself and you want [Ws2812] to take
-/// ahold of your timer.
+/// a hold of your timer.
 ///
 /// In case you use `cortex-m-rtic` and can't afford this crate
-/// to wait blockingly for you, you should try [Ws2812Direct].
+/// to wait blocking for you, you should try [Ws2812Direct].
 /// Bear in mind that you will have to take care of timing requirements
 /// yourself then.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 #![no_std]
 //! WS2812 PIO Driver for the RP2040
-///
-/// This driver implements driving a WS2812 RGB LED strip from
-/// a PIO device of the RP2040 chip.
-///
-/// You should reach to [Ws2812] if you run the main loop
-/// of your controller yourself and you want [Ws2812] to take
-/// a hold of your timer.
-///
-/// In case you use `cortex-m-rtic` and can't afford this crate
-/// to wait blocking for you, you should try [Ws2812Direct].
-/// Bear in mind that you will have to take care of timing requirements
-/// yourself then.
+//!
+//! This driver implements driving a WS2812 RGB LED strip from
+//! a PIO device of the RP2040 chip.
+//!
+//! You should reach to [Ws2812] if you run the main loop
+//! of your controller yourself and you want [Ws2812] to take
+//! a hold of your timer.
+//!
+//! In case you use `cortex-m-rtic` and can't afford this crate
+//! to wait blocking for you, you should try [Ws2812Direct].
+//! Bear in mind that you will have to take care of timing requirements
+//! yourself then.
 
 use cortex_m;
 use embedded_hal::timer::CountDown;


### PR DESCRIPTION
As discussed on Matrix here is my PR that proposes a way to access Ws2812 LED chains without the 60 microsecond pre delay.

Use case here was a _rtic_ context.