### PR TITLE
fix typo in pio nop instruction delay

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ where
         a.jmp_with_delay_and_side_set(pio::JmpCondition::Always, &mut wrap_target, T2 - 1, 1);
         a.bind(&mut do_zero);
         // Do data bit = 0
-        a.nop_with_delay_and_side_set(T2 - 2, 0);
+        a.nop_with_delay_and_side_set(T2 - 1, 0);
         a.bind(&mut wrap_source);
         let program = a.assemble_with_wrap(wrap_source, wrap_target);
 


### PR DESCRIPTION
fix typo in the delay of the nop instruction.

`a.nop_with_delay_and_side_set(T2 - 2, 0)` to `a.nop_with_delay_and_side_set(T2 - 1, 0)`

This is in accordance with the offical raspberry pi ws2812 pio example.
https://github.com/raspberrypi/pico-examples/blob/afd1d2008f3fb3fa7a837dd1bdf17a6fecbc57fe/pio/ws2812/ws2812.pio#L25

closes #8 