### PR TITLE
Allow rp2040-hal 0.4 or 0.5 as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ithinuel/ws2812-pio-rs/"
 [dependencies]
 embedded-hal = "0.2.5"
 embedded-time = "0.12.0"
-rp2040-hal = "0.4.0"
+rp2040-hal = ">=0.4.0, <0.6.0"
 pio = "0.2.0"
 smart-leds-trait = "0.2.1"
 nb = "1.0.0"


### PR DESCRIPTION
There has been no breaking changes in PIO functionality between HAL 0.4.0 and 0.5.0, so we should allow either version to be used as a dependency.
This will allow us to get a new HAL release out.
We should also push a new minor version update of ws2812-pio-rs to crates.io with this change.